### PR TITLE
fix edge case

### DIFF
--- a/scripts/chippedsaw.zs
+++ b/scripts/chippedsaw.zs
@@ -3,7 +3,7 @@ import crafttweaker.api.item.IItemStack;
 for tag in <tagmanager:items>.tags() {
     if tag.id().namespace == "chipped" {
         for item in tag {
-            <recipetype:create:cutting>.addJsonRecipe("chipsaw_"+item.registryName.path, {
+            <recipetype:create:cutting>.addJsonRecipe("chipsaw_" + item.registryName.namespace + "_"+item.registryName.path, {
                 ingredients: [tag],
                 results: [(item as IItemStack)],
                 processingTime: 50


### PR DESCRIPTION
turns out a few recipes got duplicated ids. eg: crafttweaker:chipsaw_crying_obsidian which applies for any chipped crying obsidian into vanilla. and for the chipped crying obsidian